### PR TITLE
fix to ensure logger is started for exunits' `capture_log`

### DIFF
--- a/lib/muzak/config.ex
+++ b/lib/muzak/config.ex
@@ -18,6 +18,7 @@ defmodule Muzak.Config do
     Mix.Task.run("compile", args)
     Mix.Task.run("app.start", args)
     Application.ensure_loaded(:ex_unit)
+    :ok = Application.ensure_started(:logger)
     opts = get_opts(args)
 
     {matched_test_files, test_paths, ex_unit_opts} = configure_ex_unit(opts)


### PR DESCRIPTION
In case `Logger` is not being started by the application/library it can't be used by `ExUnit` with `capture_log`. `Logger` must be started in order to run `Muzak`. The comments in this specific module indicated to me this was the best place to add this oneliner.

This fixes:
```
** (RuntimeError) cannot capture_log/2 because the :logger application was not started
    (ex_unit 1.11.1) lib/ex_unit/capture_log.ex:99: ExUnit.CaptureLog.add_capture/2
    (ex_unit 1.11.1) lib/ex_unit/capture_log.ex:70: ExUnit.CaptureLog.capture_log/2
    (muzak 1.0.1) lib/muzak/runner.ex:202: Muzak.Runner.run_silent/1
    (muzak 1.0.1) lib/muzak/runner.ex:37: Muzak.Runner.run_mutation/3
    (muzak 1.0.1) lib/muzak/runner.ex:15: anonymous fn/4 in Muzak.Runner.run_test_loop/2
    (elixir 1.11.1) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
    (muzak 1.0.1) lib/muzak/runner.ex:13: Muzak.Runner.run_test_loop/2
    (muzak 1.0.1) lib/muzak.ex:7: Muzak.run/1
```

More details here: https://github.com/tverlaan/titlex/runs/1413100580?check_suite_focus=true#step:6:7

Ps. Awesome library, great work!