### PR TITLE
Fixing the ExUnit async run logic to work on Elixir 1.12

### DIFF
--- a/lib/muzak/runner.ex
+++ b/lib/muzak/runner.ex
@@ -283,13 +283,13 @@ defmodule Muzak.Runner do
   end
 
   defp require_and_run(matched_test_files) do
-    task = Task.async(ExUnit, :run, [])
+    task = ExUnit.async_run()
 
     try do
       case Kernel.ParallelCompiler.require(matched_test_files, []) do
         {:ok, _, _} ->
           ExUnit.Server.modules_loaded()
-          {:ok, Task.await(task, :infinity)}
+          {:ok, ExUnit.await_run(task)}
 
         {:error, _, _} ->
           Task.shutdown(task, :brutal_kill)


### PR DESCRIPTION
Muzak was not working on Elixir 1.12, I debuged it and it was basically
not requiring any tests, so there was no fail at all.

I couldn't find the exact reason for it, but I saw there was the introduction
of the function `ExUnit.async_run`, so I changed the `Task.async` to
call it and everything worked!